### PR TITLE
Use `Megatron-LM` flops estimations for the TFLOPS calc

### DIFF
--- a/models/qwen3/model.py
+++ b/models/qwen3/model.py
@@ -303,7 +303,7 @@ class Qwen3ForCausalLM(nn.Module):
         )
         model.rope_cos = cos
         model.rope_sin = sin
-        return model
+        return model, cfg
 
 
 def load_safetensors_into(

--- a/models/qwen3_5/config.py
+++ b/models/qwen3_5/config.py
@@ -45,7 +45,7 @@ class Qwen3_5VisionConfig:
     deepstack_visual_indexes: list[int]
 
 @dataclass
-class Qwen3VLConfig:
+class Qwen3_5Config:
     text: Qwen3_5TextConfig
     vision: Qwen3_5VisionConfig
     image_token_id: int
@@ -56,7 +56,7 @@ class Qwen3VLConfig:
     torch_dtype: str = "bfloat16"
 
     @classmethod
-    def from_json(cls, path: str) -> "Qwen3VLConfig":
+    def from_json(cls, path: str) -> "Qwen3_5Config":
         with open(path, "r") as f:
             raw = json.load(f)
         tc = raw["text_config"]

--- a/models/qwen3_5/model.py
+++ b/models/qwen3_5/model.py
@@ -12,7 +12,7 @@ from fla.modules.fused_norm_gate import rms_norm_gated as _fla_rms_norm_gated
 from causal_conv1d import causal_conv1d_fn as _causal_conv1d_fn
 
 from models.qwen3_5.config import (
-    Qwen3VLConfig, Qwen3_5TextConfig, Qwen3_5VisionConfig
+    Qwen3_5Config, Qwen3_5TextConfig, Qwen3_5VisionConfig
 )
 from models.qwen3_5.utils import (
     _dtensor_unwrap,
@@ -563,13 +563,13 @@ class Qwen3_5Inner(nn.Module):
     """HF name: `model`. Groups `language_model` and `visual`.
     This is only used to match the state keys. """
 
-    def __init__(self, cfg: Qwen3VLConfig):
+    def __init__(self, cfg: Qwen3_5Config):
         super().__init__()
         self.language_model = LanguageModel(cfg.text)
         self.visual = VisionModel(cfg.vision)
 
 class Qwen3_5ForCausalLM(nn.Module):
-    def __init__(self, cfg: Qwen3VLConfig, **kwargs):
+    def __init__(self, cfg: Qwen3_5Config, **kwargs):
         super().__init__()
         self.cfg = cfg
         self.model = Qwen3_5Inner(cfg)
@@ -805,7 +805,7 @@ class Qwen3_5ForCausalLM(nn.Module):
         load_vision: bool = True,
     ) -> "Qwen3_5ForCausalLM":
         snapshot_dir = Path(snapshot_dir)
-        cfg = Qwen3VLConfig.from_json(snapshot_dir / "config.json")
+        cfg = Qwen3_5Config.from_json(snapshot_dir / "config.json")
         if dtype is None:
             dtype = {
                 "bfloat16": torch.bfloat16,
@@ -850,5 +850,4 @@ class Qwen3_5ForCausalLM(nn.Module):
             ** (torch.arange(0, rope_dim, 2, dtype=torch.float32, device=device) / rope_dim)
         )
         model.text_inv_freq = text_inv
-        return model
-
+        return model, cfg

--- a/models/qwen3_vl/model.py
+++ b/models/qwen3_vl/model.py
@@ -63,9 +63,6 @@ def causal_lm_loss(
         ignore_index=ignore_index,
     )
 
-
-# ------------------------------------------------------------------- config
-
 @dataclass
 class Qwen3VLTextConfig:
     vocab_size: int
@@ -896,7 +893,7 @@ class Qwen3VLForCausalLM(nn.Module):
             ** (torch.arange(0, head_dim, 2, dtype=torch.float32, device=device) / head_dim)
         )
         model.text_inv_freq = text_inv
-        return model
+        return model, cfg
 
 def load_safetensors_into(
     model: Qwen3VLForCausalLM,

--- a/train/flops_estimation.py
+++ b/train/flops_estimation.py
@@ -1,0 +1,207 @@
+import torch
+from train.config import ModelType
+
+from models.qwen3_vl.model import Qwen3VLConfig
+from models.qwen3_5.model import Qwen3_5Config
+
+def get_dense_model_nparams_and_flops(
+    model_type: ModelType,
+    model_config: Qwen3_5Config | Qwen3VLConfig,
+    model: torch.nn.Module,
+    seq_len: int,
+) -> tuple[int, int]:
+    nparams = sum(p.numel() for p in model.parameters())
+
+    num_flops_per_token = flops_estimation(model_type, model_config, seq_len)
+
+    return int(nparams), int(num_flops_per_token)
+
+# - 3x: Each GEMM in the model needs to be performed 3 times (forward pass,
+#       backward wgrad [weight gradient], backward dgrad [data gradient]).
+global forward_backward_expansion_factor
+forward_backward_expansion_factor = 3
+# - 2x: A GEMM of a m*n tensor with a n*k tensor requires 2mnk floating-point operations.
+global fma_expansion_factor
+fma_expansion_factor = 2
+
+def flops_estimation(model_type: ModelType, model_config: Qwen3VLConfig | Qwen3_5Config, seq_len: int):
+    """
+    Taken from Megatron-Energon
+
+    see: https://github.com/NVIDIA/Megatron-LM/blob/ad58411ddb396aeb196f6a08bd9c4000a0f10361/megatron/training/training.py#L290
+    """
+
+    def mlp_layer_flops(hidden_size, intermediate_size, swiglu=False):
+        """Calculate FLOPs for an MLP layer."""
+        # - 3x (SwiGLU enabled): h->2*ffn_h GEMM and ffn_h->h GEMM are stacked.
+        # - 2x (SwiGLU disabled): h->ffn_h GEMM and ffn_h->h GEMM are stacked.
+        ffn_expansion_factor = 3 if swiglu else 2
+        return intermediate_size * ffn_expansion_factor * hidden_size * forward_backward_expansion_factor * fma_expansion_factor
+
+    def logits_layer_flops(hidden_size, vocab_size):
+        return forward_backward_expansion_factor * fma_expansion_factor * hidden_size * vocab_size
+
+    def self_attn_flops(
+            kv_channels,
+            num_heads,
+            num_kv_heads,
+            hidden_size,
+            seq_len,
+            attention_output_gate=False,
+    ):
+        query_projection_size = kv_channels * num_heads
+        key_projection_size = kv_channels * num_kv_heads
+        value_projection_size = kv_channels * num_kv_heads
+        gate_projection_size = query_projection_size if attention_output_gate else 0
+
+        standard_self_attn_term = (
+            forward_backward_expansion_factor
+            * fma_expansion_factor
+            * (
+                ## qkv proj
+                hidden_size
+                * (
+                    query_projection_size
+                    + key_projection_size
+                    + value_projection_size
+                    + gate_projection_size
+                )
+                ## core attention
+                + query_projection_size
+                * seq_len
+                / 2  # causal mask (only half of the mask is non-zero)
+                * 2  # QK^T and (QK^T)V
+                ## out proj
+                + query_projection_size
+                * hidden_size
+            )
+        )
+
+        return standard_self_attn_term
+
+    def gdn_layer_flops(
+            hidden_size,
+            qk_head_dim,
+            v_head_dim,
+            num_qk_heads,
+            num_v_heads,
+            conv_kernel_dim,
+    ):
+        """Approximate FLOPs for a Gated DeltaNet (linear-attention) layer.
+
+        Megatron only approximates the GDN block: the in/out projections and the
+        depthwise causal conv are counted exactly, while the gated delta-rule
+        recurrence is approximated by `num_v_heads * v_head_dim**2 * 4` (no
+        quadratic sequence term, unlike full attention).
+        """
+        qk_dim = qk_head_dim * num_qk_heads
+        v_dim = v_head_dim * num_v_heads
+
+        return (
+            forward_backward_expansion_factor
+            * fma_expansion_factor
+            * (
+                ## in_proj: qkv (2*qk_dim + v_dim) + z (v_dim) + a/b (num_v_heads each)
+                hidden_size * (2 * qk_dim + 2 * v_dim + 2 * num_v_heads)
+                ## depthwise causal conv1d over the conv channels (2*qk_dim + v_dim)
+                + conv_kernel_dim * (2 * qk_dim + v_dim)
+                ## gated delta-rule recurrence (approximation)
+                + num_v_heads * (v_head_dim ** 2) * 4
+                ## out_proj: v_dim -> hidden_size
+                + hidden_size * v_dim
+            )
+        )
+
+    def vision_flops(model_config: Qwen3VLConfig | Qwen3_5Config):
+        """Vision tower (shared by Qwen3-VL and Qwen3.5): non-gated attention + non-gated MLP."""
+        vision_kv_channels = model_config.vision.hidden_size // model_config.vision.num_heads
+        vision_hidden_size = model_config.vision.hidden_size
+        vision_intermediate_size = model_config.vision.intermediate_size
+        vision_num_heads = model_config.vision.num_heads
+        vision_num_kv_heads = model_config.vision.num_heads
+        vision_num_layers = model_config.vision.depth
+
+        vision_self_attn_term = self_attn_flops(vision_kv_channels, vision_num_heads, vision_num_kv_heads, vision_hidden_size, seq_len)
+        vision_mlp_term = mlp_layer_flops(vision_hidden_size, vision_intermediate_size, swiglu=False)
+
+        return (
+            vision_self_attn_term * vision_num_layers
+            + vision_mlp_term * vision_num_layers
+        )
+
+    def qwen3_vl_flops(model_config: Qwen3VLConfig | Qwen3_5Config):
+        is_tied = model_config.text.tie_word_embeddings
+        # Qwen3 carries an explicit head_dim that may differ from hidden_size // num_heads.
+        kv_channels = model_config.text.head_dim
+        hidden_size = model_config.text.hidden_size
+        intermediate_size = model_config.text.intermediate_size
+        num_heads = model_config.text.num_attention_heads
+        num_kv_heads = model_config.text.num_key_value_heads
+
+        vocab_size = model_config.text.vocab_size
+        num_layers = model_config.text.num_hidden_layers
+
+        # Qwen3-VL attention has no output gate; the text MLP is SwiGLU (gate/up/down).
+        self_attn_term = self_attn_flops(kv_channels, num_heads, num_kv_heads, hidden_size, seq_len)
+        mlp_term = mlp_layer_flops(hidden_size, intermediate_size, swiglu=True)
+        logits_term = logits_layer_flops(hidden_size, vocab_size)
+
+        text_total_flops = (
+            self_attn_term * num_layers
+            + mlp_term * num_layers
+            + logits_term
+        )
+
+        return text_total_flops + vision_flops(model_config)
+
+    def qwen3_5_flops(model_config: Qwen3_5Config):
+        text = model_config.text
+        # Qwen3 carries an explicit head_dim that may differ from hidden_size // num_heads.
+        kv_channels = text.head_dim
+        hidden_size = text.hidden_size
+        intermediate_size = text.intermediate_size
+        num_heads = text.num_attention_heads
+        num_kv_heads = text.num_key_value_heads
+
+        vocab_size = text.vocab_size
+        num_layers = text.num_hidden_layers
+
+        # Hybrid split: every `full_attention_interval`-th layer is full attention,
+        # the rest are Gated DeltaNet. Mirrors LanguageModel.__init__ in the model.
+        num_full_attn_layers = sum(
+            1 for i in range(num_layers) if (i + 1) % text.full_attention_interval == 0
+        )
+        num_linear_attn_layers = num_layers - num_full_attn_layers
+
+        # Qwen3.5 full attention has an output gate (q_proj emits q + gate).
+        full_attn_term = self_attn_flops(
+            kv_channels, num_heads, num_kv_heads, hidden_size, seq_len,
+            attention_output_gate=True,
+        )
+        gdn_term = gdn_layer_flops(
+            hidden_size,
+            qk_head_dim=text.linear_key_head_dim,
+            v_head_dim=text.linear_value_head_dim,
+            num_qk_heads=text.linear_num_key_heads,
+            num_v_heads=text.linear_num_value_heads,
+            conv_kernel_dim=text.linear_conv_kernel_dim,
+        )
+        # Every decoder layer (full attention or GDN) carries a SwiGLU MLP.
+        mlp_term = mlp_layer_flops(hidden_size, intermediate_size, swiglu=True)
+        logits_term = logits_layer_flops(hidden_size, vocab_size)
+
+        text_total_flops = (
+            full_attn_term * num_full_attn_layers
+            + gdn_term * num_linear_attn_layers
+            + mlp_term * num_layers
+            + logits_term
+        )
+
+        return text_total_flops + vision_flops(model_config)
+
+    if model_type is ModelType.Qwen3_vl:
+        return qwen3_vl_flops(model_config)
+    elif model_type is ModelType.Qwen3_5:
+        return qwen3_5_flops(model_config)
+    else:
+        raise NotImplementedError()

--- a/train/train_qwen.py
+++ b/train/train_qwen.py
@@ -49,8 +49,6 @@ from train.utils import (
     dist_max,
     dist_sum,
 
-    get_dense_model_nparams_and_flops,
-
     select_text_model,
     select_vision_model,
     select_model_class,
@@ -58,6 +56,7 @@ from train.utils import (
     load_text_model,
     load_vision_model,
 )
+from train.flops_estimation import get_dense_model_nparams_and_flops
 
 torch._logging.set_logs(graph_code=True)
 torch._inductor.config.fx_graph_cache = True
@@ -127,11 +126,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         else:
             raise NotImplementedError(f"model not supported: {self.model_args.model_name}")
 
-        self.model = select_model_class(self.model_type, self.model_args, self.training_args)
+        self.model, self.cfg_model = select_model_class(self.model_type, self.model_args, self.training_args)
 
         # we calculate the flops per token used to get the MFU number
         num_params, self.flops_per_token = get_dense_model_nparams_and_flops(
-            self.model_args.model_name,
+            self.model_type,
+            self.cfg_model,
             self.model,
             seq_len=int(self.data_args.seq_len),
         )
@@ -447,8 +447,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         # GB200 (JUP) and SXM H100 (MN5)
         peak_tflops_per_gpu = 989.4
 
-        peak_tflops_per_gpu = 1671
-
         # L40S
         #peak_tflops_per_gpu = 362
 
@@ -463,6 +461,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 f"{color.green}loss {avg_loss:.4f} "
                 f"{color.blue}tps {tps:.2f} "
                 f"{color.magenta}mfu {mfu:.1f}% "
+                f"{color.cyan}tflops {tflops_per_sec:.1f} "
                 f"{color.reset}"
                 f"time {self.train_step_delta:.3f}s "
                 f"fwd {self.fwd_bwd_time:.3f}s "

--- a/train/utils.py
+++ b/train/utils.py
@@ -233,7 +233,6 @@ class GarbageCollection:
         begin = time.monotonic()
         gc.collect(generation)
         logger.info("[GC] %s took %.2f seconds", reason, time.monotonic() - begin)
-        
 
 def select_model_class(model_type: ModelType, model_args: ModelArgs, training_args: TrainArgs):
     """
@@ -244,95 +243,33 @@ def select_model_class(model_type: ModelType, model_args: ModelArgs, training_ar
     if not os.path.exists(training_args.model_dir):
         raise ValueError(f"path with model does not exists, got: {training_args.model_dir}")
 
-    model_name = model_args.model_name.lower()
+    load_vision = not getattr(training_args, "load_vision_model", False)
+    return _select_native_model_class(training_args, model_type, load_vision=load_vision)
+    # return: model, config
 
-    if model_args.model_impl == "native":
-        load_vision = not getattr(training_args, "load_vision_model", False)
-        return _select_native_model_class(training_args, model_name, load_vision=load_vision)
-    elif model_args.model_impl != "hf":
-        raise ValueError(
-            f"Unknown model_impl '{model_args.model_impl}'. Expected 'hf' or 'native'."
-        )
-
-    if "qwen3-vl" in model_name:
-        model = Qwen3VLForConditionalGeneration.from_pretrained(
-            training_args.model_dir,
-            local_files_only=True,
-            dtype=(torch.bfloat16 if training_args.bfloat16 else None),
-        )
-
-    elif "qwen3-vl" in model_name and "a" in Path(model_name.rstrip("/")).name.lower():
-        model = Qwen3VLMoeForConditionalGeneration.from_pretrained(
-            training_args.model_dir,
-            local_files_only=True,
-            dtype=(torch.bfloat16 if training_args.bfloat16 else None),
-        )
-        raise NotImplementedError("Qwen3vl-moe finetune is not supported yet.")
-    
-    elif "qwen3.5" in model_name:
-        model = Qwen3_5ForConditionalGeneration.from_pretrained(
-            training_args.model_dir,
-            local_files_only=True,
-            dtype=(torch.bfloat16 if training_args.bfloat16 else None) ,
-        )
-    
-    elif "qwen3" in model_name:
-        model = Qwen3ForCausalLM.from_pretrained(
-            training_args.model_dir,
-            local_files_only=True,
-            dtype=(torch.bfloat16 if training_args.bfloat16 else None) ,
-        )
-
-    elif "qwen3" in model_name:
-        model = Qwen3ForCausalLM.from_pretrained(
-            training_args.model_dir,
-            local_files_only=True,
-            dtype=(torch.bfloat16 if training_args.bfloat16 else None) ,
-        )
-
-    elif "qwen2.5-vl" in model_name:
-        model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
-            training_args.model_dir,
-            local_files_only=True,
-            dtype=(torch.bfloat16 if training_args.bfloat16 else None),
-        )
-
-    elif "qwen2" in model_name:
-        model = Qwen2VLForConditionalGeneration.from_pretrained(
-            training_args.model_dir,
-            local_files_only=True,
-            dtype=(torch.bfloat16 if training_args.bfloat16 else None),
-        )
-
-    else:
-        raise ValueError(f"Unsupported model: {model_args.model_name}")
-
-    return model
-
-
-def _select_native_model_class(training_args: TrainArgs, model_name: str, load_vision: bool = True):
+def _select_native_model_class(training_args: TrainArgs, model_type: ModelType, load_vision: bool = True):
     """Dispatch to our torch-native model implementations under `models/`."""
     dtype = torch.bfloat16 if training_args.bfloat16 else torch.float32
 
-    if "qwen3-vl" in model_name:
+    if model_type is ModelType.Qwen3_vl:
         from models.qwen3_vl.model import Qwen3VLForCausalLM as NativeQwen3
-    elif "qwen3.5" in model_name:
+    elif model_type is ModelType.Qwen3_5:
         from models.qwen3_5.model import Qwen3_5ForCausalLM as NativeQwen3
-    elif "qwen3" in model_name:
+    elif model_type is ModelType.Qwen3_text:
         from models.qwen3.model import Qwen3ForCausalLM as NativeQwen3
     else:
         raise ValueError(
-            f"Unsupported model for native impl: {model_name}"
+            f"Unsupported model for native impl: {model_type}"
         )
 
-    model = NativeQwen3.from_pretrained(
+    model, config = NativeQwen3.from_pretrained(
         training_args.model_dir,
         dtype=dtype,
         device="cpu",
         load_vision=load_vision,
     )
-    logger.info(f"Loaded native {model_name} from {training_args.model_dir} (load_vision={load_vision})")
-    return model
+    logger.info(f"Loaded native {model_type} from {training_args.model_dir} (load_vision={load_vision})")
+    return model, config
 
 def select_text_model(training_args):
     model = AutoModelForCausalLM.from_pretrained(
@@ -628,48 +565,3 @@ def get_scheduler(optimizer, training_args: TrainArgs):
         return create_cosine_scheduler(optimizer, training_args)
     else:
         raise ValueError(f"Unknown scheduler type: {training_args.scheduler_type}")
-
-def get_dense_model_nparams_and_flops(
-    model_name: str,
-    model: torch.nn.Module,
-    seq_len: int,
-) -> tuple[int, int]:
-    """
-    Args:
-        model_name: str (either Qwen/Qwen3-VL-8B or 2B)
-        model: nn.Module representing the model.
-        seq_len: The sequence length in training configs.
-
-    Returns:
-        Tuple of (nparams, num_flops_per_token):
-            nparams: Total number of model parameters.
-            num_flops_per_token: Estimated number of floating point operations per token.
-    """
-    nparams = sum(p.numel() for p in model.parameters())
-    nparams_embedding = sum(
-        sum(p.numel() for p in m.parameters())
-        for m in model.children()
-        if isinstance(m, torch.nn.Embedding)
-    )
-
-    if "8B" in model_name:
-        tied = False
-    elif "9B" in model_name:
-        tied = False
-    elif "2B" in model_name:
-        tied = True
-    elif "4B" in model_name:
-        tied = True
-    elif "1.7B" in model_name:
-        tied = True
-    else:
-        # ValueError
-        return 0, 0
-    
-    # we take into account the embedding params
-    num_flops_per_token = 6 * nparams
-
-    if tied:
-        nparams = nparams - nparams_embedding
-
-    return int(nparams), int(num_flops_per_token)


### PR DESCRIPTION
Issue: #21 

- Implemented for Qwen3-VL and Qwen3.5, taking into account the GDN layers
- Provides the flops_per_token
- Solved issues with the config of the models