### PR TITLE
[feat] top_k performance logging for individual devices/ranks

### DIFF
--- a/train/config.py
+++ b/train/config.py
@@ -32,6 +32,10 @@ class Wandb:
     project_name: str = "test_151_qwen_vl"
     entity_name: str = "bsc_runs"
 
+    # per-rank Top-K performance logging
+    log_topk: bool = True
+    top_k: int = 4
+
 @dataclass
 class Training:
 

--- a/train/train_qwen.py
+++ b/train/train_qwen.py
@@ -137,6 +137,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             seq_len=int(self.data_args.seq_len),
         )
 
+        self.flops_per_token = self.flops_per_token / self.training_args.tp_size
+
         # peak bf16 TFLOPs per GPU, used for the MFU number
         # SXM H100/GH200 (MN5): 989.4 ; L40S: 362
         self.peak_tflops_per_gpu = 989.4

--- a/train/train_qwen.py
+++ b/train/train_qwen.py
@@ -48,6 +48,7 @@ from train.utils import (
     dist_mean,
     dist_max,
     dist_sum,
+    dist_all_gather,
 
     get_dense_model_nparams_and_flops,
 
@@ -135,6 +136,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             self.model,
             seq_len=int(self.data_args.seq_len),
         )
+
+        # peak bf16 TFLOPs per GPU, used for the MFU number
+        # SXM H100/GH200 (MN5): 989.4 ; L40S: 362
+        self.peak_tflops_per_gpu = 989.4
 
         logger.info(f"Number params: {num_params}")
 
@@ -434,25 +439,48 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
             yield batch
 
-    def log(self, avg_loss, max_loss, global_tokens, global_assistant_tokens, global_samples, lr):
+    def _gather_perf(self, time_delta):
+        tps = self.ntokens_since_last_log / time_delta
+        flops_per_sec = (self.flops_per_token * self.total_ntokens_since_last_log) / time_delta
+        tflops_per_sec = flops_per_sec / 1e12
+        mfu = (flops_per_sec / (self.peak_tflops_per_gpu * 1e12)) * 100
+        peak_mem_gib = torch.cuda.max_memory_allocated(self.device) / (1024 ** 3)
 
-        time_delta = time.perf_counter() - self.time_last_log
+        local = torch.tensor(
+            [tps, self.train_step_delta, self.fwd_bwd_time, tflops_per_sec, mfu, peak_mem_gib],
+            dtype=torch.float32,
+            device=self.device,
+        )
+        return dist_all_gather(local, torch.distributed.group.WORLD)
 
+    # column order produced by `_gather_perf`; True == higher is better
+    _PERF_METRIC_NAMES = ("tps", "step_time", "fwd_bwd_time", "tflops", "mfu", "mem_gib")
+    _PERF_HIGHER_IS_BETTER = (True, False, False, True, True, False)
+
+    def _topk_metrics(self, gathered):
+        """Build the perf_topk/* dict: K slowest and K fastest ranks per metric."""
+        metrics = {}
+        k = min(self.wandb_args.top_k, gathered.shape[0])
+        for j, name in enumerate(self._PERF_METRIC_NAMES):
+            col = gathered[:, j]
+            higher_better = self._PERF_HIGHER_IS_BETTER[j]
+            worst_v, worst_i = torch.topk(col, k, largest=not higher_better)
+            best_v, best_i = torch.topk(col, k, largest=higher_better)
+            for r in range(k):
+                metrics[f"perf_topk/{name}_slow_{r}"] = worst_v[r].item()
+                metrics[f"perf_topk/{name}_slow_{r}_rank"] = int(worst_i[r].item())
+                metrics[f"perf_topk/{name}_fast_{r}"] = best_v[r].item()
+                metrics[f"perf_topk/{name}_fast_{r}_rank"] = int(best_i[r].item())
+        return metrics
+
+    def log(self, avg_loss, max_loss, global_tokens, global_assistant_tokens, global_samples, lr, time_delta, gathered=None):
         tps = self.ntokens_since_last_log / time_delta
 
         step_flops = self.flops_per_token * self.total_ntokens_since_last_log
         flops_per_sec = step_flops / time_delta
         tflops_per_sec = flops_per_sec / 1e12
 
-        # GB200 (JUP) and SXM H100 (MN5)
-        peak_tflops_per_gpu = 989.4
-
-        peak_tflops_per_gpu = 1671
-
-        # L40S
-        #peak_tflops_per_gpu = 362
-
-        mfu = (flops_per_sec / (peak_tflops_per_gpu * 1e12)) * 100
+        mfu = (flops_per_sec / (self.peak_tflops_per_gpu * 1e12)) * 100
 
         color = self.color
 
@@ -488,6 +516,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             "perf/tflops_per_second": tflops_per_sec,
             "perf/mfu": mfu,
         }
+
+        if gathered is not None:
+            log_metrics.update(self._topk_metrics(gathered))
 
         wandb.log(log_metrics, step=self.global_step)
 
@@ -547,14 +578,20 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 )
             )
 
-            self.train_step_delta = (time.perf_counter() - self.time_last_log) / self.current_accum_target
+            time_delta = time.perf_counter() - self.time_last_log
+            self.train_step_delta = time_delta / self.current_accum_target
+
+            gathered = None
+            if self.wandb_args.log_topk:
+                gathered = self._gather_perf(time_delta)
 
             if self.if_log_rank():
-                self.log(avg_loss, max_loss, global_tokens, global_assistant, global_samples, lr)
+                self.log(avg_loss, max_loss, global_tokens, global_assistant, global_samples, lr, time_delta, gathered)
 
             self.total_ntokens_since_last_log = 0
             self.ntokens_since_last_log = 0
             self.samples_since_last_log = 0
+            torch.cuda.reset_peak_memory_stats(self.device)
             self.time_last_log = time.perf_counter()
 
             self.current_accum_count = 0

--- a/train/utils.py
+++ b/train/utils.py
@@ -580,6 +580,15 @@ def dist_sum(
         x, reduceOp=c10d.ReduceOp.SUM.name, mesh=mesh,
     )
 
+def dist_all_gather(x: torch.Tensor, group) -> torch.Tensor:
+    """Gather a 1-D per-rank tensor across `group`.
+
+    Returns a [world_size, x.numel()] tensor available on every rank. This is a
+    collective, so it MUST be called on all ranks of `group`.
+    """
+    x = x.contiguous()
+    return funcol.all_gather_tensor(x, gather_dim=0, group=group).reshape(-1, x.numel())
+
 def create_WSD_scheduler(optimizer, training_args: TrainArgs):
     total_steps = training_args.total_steps
     warmup_steps = training_args.warmup_steps


### PR DESCRIPTION
- Gathers metrics on ALL devices, not the DP_group
- Top-k slow/fast devices, logging which rank is also
- using an all_gather for the metrics, logging directly to wandb